### PR TITLE
Allow a custom JSON parser to be used

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 var promise = require('cb2promise');
 var Whoops  = require('whoops');
 
-var parseAsync = function(data, cb) {
+var parseAsync = function(data, parse_method, cb) {
   var content;
   var error;
 
   try {
-    content = JSON.parse(data);
+    content = parse_method(data);
   } catch (err) {
     content = {};
     error = new Whoops({
@@ -22,9 +22,9 @@ var parseAsync = function(data, cb) {
   }
 };
 
-function parseJSON(data, cb) {
-  if (arguments.length === 1) return promise(parseAsync, data);
-  return parseAsync(data, cb);
+function parseJSON(data, cb, parse_method = JSON.parse) {
+  if (!cb) return promise(parseAsync, data, parse_method);
+  return parseAsync(data, parse_method, cb);
 }
 
 module.exports = parseJSON;

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -6,7 +6,10 @@ sampleJSON  = fs.readFileSync "#{__dirname}/sample.json", encoding: 'utf8'
 describe 'parseJSON ::', ->
 
   it 'as callback', (done) ->
-    parseJSON sampleJSON, done
+    parseJSON sampleJSON, (error, content) ->
+      should.not.exist(error)
+      content.foo.should.be.equal 'bar'
+      done()
 
   it 'as promise', ->
     parseJSON(sampleJSON).then (content) ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -5,6 +5,10 @@ sampleJSON  = fs.readFileSync "#{__dirname}/sample.json", encoding: 'utf8'
 
 describe 'parseJSON ::', ->
 
+  custom_parser = (json) ->
+    json.should.be.equal sampleJSON
+    { foo: 'custom' }
+
   it 'as callback', (done) ->
     parseJSON sampleJSON, (error, content) ->
       should.not.exist(error)
@@ -14,3 +18,15 @@ describe 'parseJSON ::', ->
   it 'as promise', ->
     parseJSON(sampleJSON).then (content) ->
       content.foo.should.be.equal 'bar'
+
+  it 'as callback, with custom parser', (done) ->
+    cb = (error, content) ->
+      should.not.exist(error)
+      content.foo.should.be.equal 'custom'
+      done()
+
+    parseJSON sampleJSON, cb, custom_parser
+
+  it 'as promise, with custom parser', ->
+    parseJSON(sampleJSON, null, (custom_parser)).then (content) ->
+      content.foo.should.be.equal 'custom'


### PR DESCRIPTION
In our setup we need to use `json-bigint` to handle Big Integers without losing precision. This is not currently supported by `json-parse-async`. 

This (fairly trivial) pull request adds an extra argument to the exposed `parseJSON` method to specify the parse method to use (defaulting to `JSON.parse`), like this:

```js
const parseJson = require('json-parse-async')
const JSONbig = require('json-bigint')

// As promise:
parseJson(json, null, JSONbig.parse).then(...)

// Or, using a callback:
parseJson(json, cb, JSONbig.parse)
```

Tests have been included. I'm new to the world of CoffeeScript so feel free to point out if there are issues with my test method or anything else.